### PR TITLE
Fix parted emerge issue

### DIFF
--- a/splat.sh
+++ b/splat.sh
@@ -47,7 +47,7 @@ PATH="${PATH}:/usr/local/bin"
 get_pkg() {
   # do nothing if no arguments given
   for pkg in $*; do
-    if [ X`which ${pkg} 2>/dev/null` == X ]; then
+    if [ X`which $(basename ${pkg}) 2>/dev/null` == X ]; then
       # we need to install ${pkg}
       if [ X`which pacman 2>/dev/null` != X ]; then
         # install the Arch way
@@ -60,7 +60,7 @@ When prompted, just hit [ENTER] or type 'Y' and hit
 
 EOF
         # perform the install
-        pacman -S "${pkg}"
+        pacman -S "$(basename ${pkg})"
       else
         # install the gentoo/chromeos way
         if [ X`which emerge 2>/dev/null` == X ]; then
@@ -140,7 +140,7 @@ set -e
 ###
 # make sure the needed tools are present
 ###
-get_pkg wget parted
+get_pkg wget sys-block/parted
 
 # download the ArchLinuxARM tarball and MD5 files
 for f in "${TARBALL}" "${TARBALL}.md5"; do

--- a/splat.sh
+++ b/splat.sh
@@ -140,7 +140,12 @@ set -e
 ###
 # make sure the needed tools are present
 ###
-get_pkg wget sys-block/parted
+if [ X`which pacman 2>/dev/null` == X ]
+then
+  get_pkg net-misc/wget sys-block/parted
+else
+  get_pkg wget parted
+fi
 
 # download the ArchLinuxARM tarball and MD5 files
 for f in "${TARBALL}" "${TARBALL}.md5"; do


### PR DESCRIPTION
Signed-off-by: Stefan H. Driesner <s.driesner@gmail.com>

This update is in response to updates to 'emerge' that seem to now require more explicit package names when installing software that caused my recent attempt to re-install Arch to my HP Chromebook 11 to fail.

Specifically, 'emerge parted' now fails, rather only 'emerge sys-block/parted' works now.
Similarly, 'emerge wget' fails, but 'emerge net-misc/wget' works.

By contrast, 'pacman -S wget' and/or 'pacman -S parted' still work just fine.

Because this is an 'emerge' issue, only the install when executing splat.sh in ChromeOS is affected.

This update tweaks the arguments passed to get_pkg() to accomodate this based on whether 'pacman' is available, and tweaks get_pkg() itself to handle package names with slashes in them.

Maybe there are more elegant ways of doing this, but it fixed the problem and I now have a working Arch Linux install on my HP Chromebook 11.